### PR TITLE
Add include for unordered_map in default_priors.h

### DIFF
--- a/src/kima/default_priors.h
+++ b/src/kima/default_priors.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <unordered_map>
 
 #include "DNest4.h"
 #include "Data.h"


### PR DESCRIPTION
This PR addresses a compilation error encountered on macOS 15.5 using AppleClang 17. The issue arises from the use of `std::unordered_map` in `default_priors.h` without an explicit inclusion of the `<unordered_map>` header. 

While some compilers may include this header transitively through other included files, other standard library implementations enforce stricter compliance and do not provide this inclusion implicitly. This inconsistency can result in compilation failures in environments lacking the direct inclusion. Therefore, explicitly including the header minimizes potential compilation issues by ensuring that the necessary definitions are readily available.

Thanks for all the work put into developing this package!