### PR TITLE
fix(`RVFWHMmodel`): preserve prior precision in `save_setup`

### DIFF
--- a/src/kima/ApodizedRVmodel.cpp
+++ b/src/kima/ApodizedRVmodel.cpp
@@ -947,6 +947,7 @@ string ApodizedRVmodel::description() const
 void ApodizedRVmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
     fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 

--- a/src/kima/BINARIESmodel.cpp
+++ b/src/kima/BINARIESmodel.cpp
@@ -1050,7 +1050,8 @@ string BINARIESmodel::description() const
 */
 void BINARIESmodel::save_setup() {
     std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 
@@ -1085,9 +1086,7 @@ void BINARIESmodel::save_setup() {
         fout << f << ",";
     fout << endl;
 
-    fout.precision(15);
     fout << "M0_epoch: " << data.M0_epoch << endl;
-    fout.precision(6);
 
     fout << endl;
 

--- a/src/kima/ETVmodel.cpp
+++ b/src/kima/ETVmodel.cpp
@@ -422,7 +422,8 @@ string ETVmodel::description() const
 void ETVmodel::save_setup() {
 
     std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 
@@ -444,8 +445,6 @@ void ETVmodel::save_setup() {
     fout << "file: " << data._datafile << endl;
     fout << "skip: " << data._skip << endl;
 
-
-    fout.precision(12);
 
     fout << endl;
 

--- a/src/kima/GAIAmodel.cpp
+++ b/src/kima/GAIAmodel.cpp
@@ -653,7 +653,8 @@ string GAIAmodel::description() const
 */
 void GAIAmodel::save_setup() {
     std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 
@@ -680,9 +681,7 @@ void GAIAmodel::save_setup() {
     //     fout << f << ",";
     // fout << endl;
 
-    fout.precision(15);
     fout << "M0_epoch: " << data.M0_epoch << endl;
-    fout.precision(6);
 
     fout << endl;
 

--- a/src/kima/GPmodel.cpp
+++ b/src/kima/GPmodel.cpp
@@ -1104,7 +1104,8 @@ string GPmodel::description() const
 */
 void GPmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 
@@ -1145,9 +1146,7 @@ void GPmodel::save_setup() {
         fout << n << ",";
     fout << endl;
 
-    fout.precision(15);
     fout << "M0_epoch: " << data.M0_epoch << endl;
-    fout.precision(6);
 
     fout << endl;
 

--- a/src/kima/OutlierRVmodel.cpp
+++ b/src/kima/OutlierRVmodel.cpp
@@ -670,7 +670,8 @@ string OutlierRVmodel::description() const
 */
 void OutlierRVmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 
@@ -702,9 +703,7 @@ void OutlierRVmodel::save_setup() {
         fout << f << ",";
     fout << endl;
 
-    fout.precision(15);
     fout << "M0_epoch: " << data.M0_epoch << endl;
-    fout.precision(6);
 
     fout << endl;
 

--- a/src/kima/RVFWHMRHKmodel.cpp
+++ b/src/kima/RVFWHMRHKmodel.cpp
@@ -1324,7 +1324,8 @@ string RVFWHMRHKmodel::description() const
 
 void RVFWHMRHKmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl;
 
@@ -1364,9 +1365,7 @@ void RVFWHMRHKmodel::save_setup() {
         fout << f << ",";
     fout << endl;
 
-    fout.precision(15);
     fout << "M0_epoch: " << data.M0_epoch << endl;
-    fout.precision(6);
 
     fout << endl;
 

--- a/src/kima/RVFWHMmodel.cpp
+++ b/src/kima/RVFWHMmodel.cpp
@@ -1130,7 +1130,7 @@ string RVFWHMmodel::description() const
 
 void RVFWHMmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
 
     fout << "; " << timestamp() << endl << endl;
 
@@ -1171,9 +1171,7 @@ void RVFWHMmodel::save_setup() {
         fout << f << ",";
     fout << endl;
 
-    fout.precision(15);
     fout << "M0_epoch: " << data.M0_epoch << endl;
-    fout.precision(6);
 
     fout << endl;
 

--- a/src/kima/RVFWHMmodel.cpp
+++ b/src/kima/RVFWHMmodel.cpp
@@ -1131,6 +1131,7 @@ string RVFWHMmodel::description() const
 void RVFWHMmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
     fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 

--- a/src/kima/RVGAIAmodel.cpp
+++ b/src/kima/RVGAIAmodel.cpp
@@ -1041,7 +1041,8 @@ string RVGAIAmodel::description() const
 */
 void RVGAIAmodel::save_setup() {
     std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 
@@ -1081,9 +1082,7 @@ void RVGAIAmodel::save_setup() {
         fout << f << ",";
     fout << endl;
 
-    fout.precision(15);
     fout << "M0_epoch: " << GAIA_data.M0_epoch << endl;
-    fout.precision(6);
 
     fout << endl;
 

--- a/src/kima/RVHGPMmodel.cpp
+++ b/src/kima/RVHGPMmodel.cpp
@@ -1033,6 +1033,7 @@ string RVHGPMmodel::description() const
 void RVHGPMmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
     fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 

--- a/src/kima/RVmodel.cpp
+++ b/src/kima/RVmodel.cpp
@@ -956,6 +956,7 @@ string RVmodel::description() const
 void RVmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
     fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 

--- a/src/kima/SPLEAFmodel.cpp
+++ b/src/kima/SPLEAFmodel.cpp
@@ -1147,7 +1147,7 @@ string SPLEAFmodel::description() const
 */
 void SPLEAFmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
     fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;

--- a/src/kima/TRANSITmodel.cpp
+++ b/src/kima/TRANSITmodel.cpp
@@ -472,7 +472,8 @@ string TRANSITmodel::description() const
 */
 void TRANSITmodel::save_setup() {
 	std::fstream fout("kima_model_setup.txt", std::ios::out);
-    fout << std::boolalpha;
+    fout << std::boolalpha << std::fixed;
+    fout.precision(15);
 
     fout << "; " << timestamp() << endl << endl;
 
@@ -502,9 +503,7 @@ void TRANSITmodel::save_setup() {
         fout << f << ",";
     fout << endl;
 
-    fout.precision(15);
     fout << "M0_epoch: " << data.M0_epoch << endl;
-    fout.precision(6);
 
     fout << endl;
 


### PR DESCRIPTION
### Problem

`RVFWHMmodel::save_setup` writes the setup file without `std::fixed`, so the default C++ stream formatting uses only 6 significant figures. For large BJD-scale values, this truncates distinct prior bounds to the same value — e.g. `Tcprior` bounds `2458520.644883` and `2458520.656756` both become `2.45852e+06`. When `load_results` reads the setup file back, it fails with:

```
ValueError: Uniform distribution must have lower < upper limits
```

This affects any prior whose bounds are large-magnitude values, and is likely the root cause of the error reported in #24.

`RVmodel` already uses `std::fixed` and is not affected.

### Fix

- Add `std::fixed` to `fout` at the start of `save_setup`, matching the approach in `RVmodel`
- Remove the `fout.precision(15)` / `fout.precision(6)` workaround around `M0_epoch`, which was a narrow patch for the same root cause

After applying this fix and recompiling, `RVFWHMmodel` runs as before, but `load_results` now correctly reads back the setup file for models with the correct large-magnitude prior bounds for  BJD-scale transit times, allowing me to use this model.

### Note

The same pattern existed in `BINARIESmodel`, `ETVmodel`, `GAIAmodel`, `GPmodel`, `RVFWHMRHKmodel`, `RVGAIAmodel`, `SPLEAFmodel`, and `TRANSITmodel`. I have applied the same fix to all of these, and additionally added `fout.precision(15)` globally across all models to ensure full double precision is preserved regardless of the magnitude of prior bounds.

Let me know what you think!

Cheers,
David