### PR TITLE
Ensure known object actually works when using the RVHGPMmodel

### DIFF
--- a/src/kima/RVHGPMmodel.cpp
+++ b/src/kima/RVHGPMmodel.cpp
@@ -124,7 +124,7 @@ void RVHGPMmodel::setPriors()  // BUG: should be done by only one thread!
     if (known_object) { 
         for (size_t i = 0; i < n_known_object; i++)
         {
-            if (!KO_Pprior[i] || !KO_Kprior[i] || !KO_eprior[i] || !KO_phiprior[i] || !KO_wprior[i])
+            if (!KO_Pprior[i] || !KO_Kprior[i] || !KO_eprior[i] || !KO_phiprior[i] || !KO_wprior[i] || !KO_iprior[i] || !KO_Wprior[i])
             {
                 std::string p = "KO_Pprior, KO_Kprior, KO_eprior, KO_phiprior, KO_wprior, KO_iprior, KO_Wprior";
                 std::string msg = "When known_object=true, must set explicit priors for each of " + p;
@@ -394,20 +394,37 @@ void RVHGPMmodel::calculate_mu()
 void RVHGPMmodel::remove_known_object()
 {
     for (int j = 0; j < n_known_object; j++) {
-        auto v = brandt::keplerian(data.t, KO_P[j], KO_K[j], KO_e[j], KO_w[j], KO_phi[j], data.M0_epoch);
+        auto [v, pm] = brandt::keplerian_rvpm(data.t, {pm_data.epoch_ra_hip, pm_data.epoch_dec_hip, pm_data.epoch_ra_gaia, pm_data.epoch_dec_gaia}, 
+                                                parallax, KO_P[j], KO_K[j], KO_e[j], KO_w[j], KO_phi[j], data.M0_epoch, KO_i[j], KO_W[j]);
         for (size_t i = 0; i < data.N(); i++) {
             mu[i] -= v[i];
         }
+
+        mu_pm[0] -= pm[0][0]; // pm RA Hipparcos
+        mu_pm[1] -= pm[1][0]; // pm Dec Hipparcos
+        mu_pm[2] -= pm[0][1]; // pm RA Gaia
+        mu_pm[3] -= pm[1][1]; // pm Dec Gaia
+        mu_pm[4] -= pm[2][0]; // pm RA Hipparcos-Gaia
+        mu_pm[5] -= pm[2][1]; // pm Dec Hipparcos-Gaia
     }
 }
 
 void RVHGPMmodel::add_known_object()
 {
     for (int j = 0; j < n_known_object; j++) {
-        auto v = brandt::keplerian(data.t, KO_P[j], KO_K[j], KO_e[j], KO_w[j], KO_phi[j], data.M0_epoch);
+        auto [v, pm] = brandt::keplerian_rvpm(data.t, {pm_data.epoch_ra_hip, pm_data.epoch_dec_hip, pm_data.epoch_ra_gaia, pm_data.epoch_dec_gaia}, 
+                                                parallax, KO_P[j], KO_K[j], KO_e[j], KO_w[j], KO_phi[j], data.M0_epoch, KO_i[j], KO_W[j]);
         for (size_t i = 0; i < data.N(); i++) {
             mu[i] += v[i];
         }
+
+        mu_pm[0] += pm[0][0]; // pm RA Hipparcos
+        mu_pm[1] += pm[1][0]; // pm Dec Hipparcos
+        mu_pm[2] += pm[0][1]; // pm RA Gaia
+        mu_pm[3] += pm[1][1]; // pm Dec Gaia
+        mu_pm[4] += pm[2][0]; // pm RA Hipparcos-Gaia
+        mu_pm[5] += pm[2][1]; // pm Dec Hipparcos-Gaia
+
     }
 }
 
@@ -553,7 +570,7 @@ int RVHGPMmodel::is_stable() const
             all_components.resize(components.size() + n_known_object);
             size_t i = 0;
             for (size_t j = components.size(); j < components.size() + n_known_object; j++) {
-                all_components[j] = {KO_P[i], KO_K[i], KO_phi[i], KO_e[i], KO_w[i]};
+                all_components[j] = {KO_P[i], KO_K[i], KO_phi[i], KO_e[i], KO_w[i], KO_i[i], KO_W[i]};
                 i++;
             }
             stable_planets = AMD::AMD_stable(all_components, star_mass);
@@ -568,7 +585,7 @@ int RVHGPMmodel::is_stable() const
         vector<vector<double>> ko_components;
         ko_components.resize(n_known_object);
         for (int j = 0; j < n_known_object; j++) {
-            ko_components[j] = {KO_P[j], KO_K[j], KO_phi[j], KO_e[j], KO_w[j]};
+            ko_components[j] = {KO_P[j], KO_K[j], KO_phi[j], KO_e[j], KO_w[j], KO_i[j], KO_W[j]};
         }
         stable_known_object = AMD::AMD_stable(ko_components, star_mass);
         return stable_known_object;
@@ -1239,6 +1256,8 @@ void RVHGPMmodel::save_setup() {
             fout << "eprior_" << i << ": " << *KO_eprior[i] << endl;
             fout << "phiprior_" << i << ": " << *KO_phiprior[i] << endl;
             fout << "wprior_" << i << ": " << *KO_wprior[i] << endl;
+            fout << "iprior_" << i << ": " << *KO_iprior[i] << endl;
+            fout << "Wprior_" << i << ": " << *KO_Wprior[i] << endl;
         }
     }
 
@@ -1489,6 +1508,14 @@ NB_MODULE(RVHGPMmodel, m) {
                      [](RVHGPMmodel &m) { return m.KO_phiprior; },
                      [](RVHGPMmodel &m, std::vector<distribution>& vd) { m.KO_phiprior = vd; },
                      "Prior for KO mean anomaly(ies)")
+        .def_prop_rw("KO_iprior",
+                     [](RVHGPMmodel &m) { return m.KO_iprior; },
+                     [](RVHGPMmodel &m, std::vector<distribution>& vd) { m.KO_iprior = vd; },
+                     "Prior for KO inclination")
+        .def_prop_rw("KO_Wprior",
+                     [](RVHGPMmodel &m) { return m.KO_Wprior; },
+                     [](RVHGPMmodel &m, std::vector<distribution>& vd) { m.KO_Wprior = vd; },
+                     "Prior for KO longitude of ascending node")
 
         // transiting planet priors
         // ? should these setters check if transiting_planet is true?

--- a/src/kima/RVHGPMmodel.h
+++ b/src/kima/RVHGPMmodel.h
@@ -86,7 +86,7 @@ class KIMA_API RVHGPMmodel
         double pm_ra_bary, pm_dec_bary;
 
         // Parameters for the known object, if set
-        // double KO_P, KO_K, KO_e, KO_phi, KO_w;
+        // double KO_P, KO_K, KO_e, KO_phi, KO_w, KO_i, KO_W;
         std::vector<double> KO_P;
         std::vector<double> KO_K;
         std::vector<double> KO_e;

--- a/src/kima/pykima/display.py
+++ b/src/kima/pykima/display.py
@@ -4065,7 +4065,7 @@ def hist_astrometric_solution(res, show_prior=False, axs=None, **kwargs):
 
 
 def plot_hgpm(res, pm_data, ncurves=50, normalize=False,
-              include_planets=None, **kwargs):
+              include_planets=None, include_known_object=False, **kwargs):
     if res.model != MODELS.RVHGPMmodel:
         print('Model is not RVHGPMmodel! plot_hgpm() doing nothing...')
         return
@@ -4135,7 +4135,50 @@ def plot_hgpm(res, pm_data, ncurves=50, normalize=False,
             axs[2].axhline(pm_dec_bary, **kw_line)
             axs[0].plot(t_ra - 5e4, pm_ra_bary + model_ra, **kw)
             axs[2].plot(t_dec - 5e4, pm_dec_bary + model_dec, **kw)
-    
+
+
+        if include_known_object and res.KO:
+
+            KO_model_ra = np.zeros_like(t_ra)
+            KO_model_dec = np.zeros_like(t_dec)
+
+            for j in range(res.nKO):
+                
+                koP = p[res.indices['KOpars']][j]
+                koφ = p[res.indices['KOpars']][j + 2 * res.nKO]
+                koe = p[res.indices['KOpars']][j + 3 * res.nKO]
+                kow = p[res.indices['KOpars']][j + 4 * res.nKO]
+                koK = p[res.indices['KOpars']][j + 1 * res.nKO]
+                koi = p[res.indices['KOpars']][j + 5 * res.nKO]
+                koW = p[res.indices['KOpars']][j + 6 * res.nKO]
+
+                model = keplerian_rvpm(
+                    res.data.t, t_pm, 
+                    p[res.indices['parallax']], 
+                    koP, 
+                    koK,
+                    koe,
+                    kow,
+                    koφ,
+                    res.M0_epoch, 
+                    koi,
+                    koW
+                )
+                KO_model_ra += model[1]
+                KO_model_dec += model[2]
+
+
+            kw = dict(color='C0', alpha=0.1 if ncurves > 10 else 1.0, zorder=-1, lw=0.5)
+            kw_line = dict(ls='--', color='tomato', alpha=0.1)
+
+            if normalize:
+                axs[0].plot(t_ra - 5e4, KO_model_ra + pm_ra_bary, **kw)
+                axs[2].plot(t_dec - 5e4, KO_model_dec + pm_dec_bary, **kw)
+            else:
+                axs[0].plot(t_ra - 5e4, pm_ra_bary + KO_model_ra, **kw)
+                axs[2].plot(t_dec - 5e4, pm_dec_bary + KO_model_dec, **kw)
+
+            
     for ax in axs[::2]:
         ax.set_xlim(-4000, 10_000)
         # ax.set_ylim(-40, 40)
@@ -5407,7 +5450,7 @@ def report(res, hexbin=False, diagnostic=False, **kwargs):
         axs['c'].axis('off')
         axs['d'].axis('off')
     else:
-        res.plot2(ax=axs['p'], alpha=0.6)
+        res.plot2(ax=axs['p'], include_known_object=True, alpha=0.6)
         axs['p'].set(title='', ylabel='posterior', xlabel='')
 
         from .analysis import FIP
@@ -5421,7 +5464,7 @@ def report(res, hexbin=False, diagnostic=False, **kwargs):
         else:
             kw3 = dict()
 
-        res.plot3(ax1=axs['c'], ax2=axs['d'], **kw3)
+        res.plot3(ax1=axs['c'], ax2=axs['d'], include_known_object=True, **kw3)
 
         if res.ESS < 1000:
             for line in axs['c'].get_lines():

--- a/src/kima/pykima/display.py
+++ b/src/kima/pykima/display.py
@@ -4186,8 +4186,12 @@ def plot_hgpm(res, pm_data, ncurves=50, normalize=False,
     # add the "known object" label to the legend
     # alongside the Hipparcos/Gaia labels created in plot_HGPMdata
     if include_known_object and res.KO and axs[0].get_legend() is not None:
-        axs[0].legend(ncols=2, bbox_to_anchor=(0, 1.11), loc='upper left')
-
+        leg = axs[0].legend(ncols=3, bbox_to_anchor=(0, 1.11), loc='upper left')
+        # increasing the opacity of the "known object" legend entry so it is more visible
+        for handle, text in zip(leg.legend_handles, leg.get_texts()):
+            if text.get_text() == 'known object':
+                handle.set_alpha(0.5)
+                
     return fig
 
 

--- a/src/kima/pykima/display.py
+++ b/src/kima/pykima/display.py
@@ -4095,7 +4095,7 @@ def plot_hgpm(res, pm_data, ncurves=50, normalize=False,
     # handles, labels = axs[0].get_legend_handles_labels()
     # print(handles)
 
-    for i in np.random.choice(np.arange(res.ESS), size=ncurves, replace=False):
+    for icurve, i in enumerate(np.random.choice(np.arange(res.ESS), size=ncurves, replace=False)):
     # for i in range(res.ESS):
         p = res.posterior_sample[i]
 
@@ -4169,19 +4169,25 @@ def plot_hgpm(res, pm_data, ncurves=50, normalize=False,
 
 
             kw = dict(color='C0', alpha=0.1 if ncurves > 10 else 1.0, zorder=-1, lw=0.5)
+            label = 'known object' if icurve == 0 else None
 
             if normalize:
-                axs[0].plot(t_ra - 5e4, KO_model_ra + pm_ra_bary, label = "known object", **kw)
+                axs[0].plot(t_ra - 5e4, KO_model_ra + pm_ra_bary, label=label, **kw)
                 axs[2].plot(t_dec - 5e4, KO_model_dec + pm_dec_bary, **kw)
             else:
-                axs[0].plot(t_ra - 5e4, pm_ra_bary + KO_model_ra, label = "known object", **kw)
+                axs[0].plot(t_ra - 5e4, pm_ra_bary + KO_model_ra, label=label, **kw)
                 axs[2].plot(t_dec - 5e4, pm_dec_bary + KO_model_dec, **kw)
 
             
     for ax in axs[::2]:
         ax.set_xlim(-4000, 10_000)
         # ax.set_ylim(-40, 40)
-    
+
+    # add the "known object" label to the legend
+    # alongside the Hipparcos/Gaia labels created in plot_HGPMdata
+    if include_known_object and res.KO and axs[0].get_legend() is not None:
+        axs[0].legend(ncols=2, bbox_to_anchor=(0, 1.11), loc='upper left')
+
     return fig
 
 

--- a/src/kima/pykima/display.py
+++ b/src/kima/pykima/display.py
@@ -4174,7 +4174,7 @@ def plot_hgpm(res, pm_data, ncurves=50, normalize=False,
                 axs[0].plot(t_ra - 5e4, KO_model_ra + pm_ra_bary, label = "known object", **kw)
                 axs[2].plot(t_dec - 5e4, KO_model_dec + pm_dec_bary, **kw)
             else:
-                axs[0].plot(t_ra - 5e4, pm_ra_bary + KO_model_ra, **kw)
+                axs[0].plot(t_ra - 5e4, pm_ra_bary + KO_model_ra, label = "known object", **kw)
                 axs[2].plot(t_dec - 5e4, pm_dec_bary + KO_model_dec, **kw)
 
             

--- a/src/kima/pykima/display.py
+++ b/src/kima/pykima/display.py
@@ -4169,10 +4169,9 @@ def plot_hgpm(res, pm_data, ncurves=50, normalize=False,
 
 
             kw = dict(color='C0', alpha=0.1 if ncurves > 10 else 1.0, zorder=-1, lw=0.5)
-            kw_line = dict(ls='--', color='tomato', alpha=0.1)
 
             if normalize:
-                axs[0].plot(t_ra - 5e4, KO_model_ra + pm_ra_bary, **kw)
+                axs[0].plot(t_ra - 5e4, KO_model_ra + pm_ra_bary, label = "known object", **kw)
                 axs[2].plot(t_dec - 5e4, KO_model_dec + pm_dec_bary, **kw)
             else:
                 axs[0].plot(t_ra - 5e4, pm_ra_bary + KO_model_ra, **kw)

--- a/src/kima/pykima/display_hooks.py
+++ b/src/kima/pykima/display_hooks.py
@@ -60,8 +60,8 @@ def plot_HGPMdata(data, pm_ra_bary=None, pm_dec_bary=None,
     kwG = dict(fmt='o', ms=4, color='C1')
     kw = dict(fmt='o', ms=4, color='k')
 
-    axs[0].errorbar(data.epoch_ra_hip - 5e4, data.pm_ra_hip, data.sig_hip_ra, **kwH)
-    axs[0].errorbar(data.epoch_ra_gaia - 5e4, data.pm_ra_gaia, data.sig_gaia_ra, **kwG)
+    axs[0].errorbar(data.epoch_ra_hip - 5e4, data.pm_ra_hip, data.sig_hip_ra, label='Hipparcos', **kwH)
+    axs[0].errorbar(data.epoch_ra_gaia - 5e4, data.pm_ra_gaia, data.sig_gaia_ra, label='Gaia', **kwG)
     axs[1].errorbar(0.5, data.pm_ra_hg, data.sig_hg_ra, **kw, mfc="w")
     axs[1].axhline(data.pm_ra_hg, color="k", zorder=-1)
     axs[1].set(yticks=[], xticks=[], xlim=(0, 1))
@@ -85,6 +85,5 @@ def plot_HGPMdata(data, pm_ra_bary=None, pm_dec_bary=None,
     # axs[1, 3].axis('off')
 
     if show_legend:
-        axs[0].legend(['Hipparcos', 'Gaia'], ncols=2,
-                      bbox_to_anchor=(0, 1.11), loc='upper left')
+        axs[0].legend(ncols=2, bbox_to_anchor=(0, 1.11), loc='upper left')
     return fig, axs

--- a/src/kima/pykima/results.py
+++ b/src/kima/pykima/results.py
@@ -2219,7 +2219,7 @@ class KimaResults:
                 self.posteriors.KO.e = self.KOpars[:, range(3*self.nKO, 4*self.nKO)]
                 self.posteriors.KO.w = self.KOpars[:, range(4*self.nKO, 5*self.nKO)]
                 self.posteriors.KO.i = self.KOpars[:, range(5*self.nKO, 6*self.nKO)]
-                self.posteriors.KO.W = self.KOpars[:, range(6*self.nKO, 7*self.nKO)]
+                self.posteriors.KO.W = self.posteriors.KO.Ω = self.KOpars[:, range(6*self.nKO, 7*self.nKO)]
             else:
                 self.posteriors.KO.K = self.KOpars[:, range(1*self.nKO, 2*self.nKO)]
                 self.posteriors.KO.φ = self.KOpars[:, range(2*self.nKO, 3*self.nKO)]

--- a/src/kima/pykima/results.py
+++ b/src/kima/pykima/results.py
@@ -2697,6 +2697,8 @@ class KimaResults:
                 else:
                     pars = ['P', 'K', 'M0', 'e', 'w', 'wdot','cosi']
                     extra_n = 2
+            elif self.model is MODELS.RVHGPMmodel:
+                pars = ('P', 'K', 'M0', 'e', 'w', 'i', 'W')
             else:
                 pars = ('P', 'K', 'M0', 'e', 'w')
             print(((self.n_dimensions + extra_n) * ' {:>10s} ').format(*pars))

--- a/src/kima/pykima/results.py
+++ b/src/kima/pykima/results.py
@@ -1323,6 +1323,9 @@ class KimaResults:
                 n_KOparameters = 7 * self.nKO
             elif self.model is MODELS.RVGAIAmodel:
                 n_KOparameters = 7 * self.nKO
+            elif self.model is MODELS.RVHGPMmodel:
+                # P, K, phi, e, w, i, W
+                n_KOparameters = 7 * self.nKO
             elif self.model is MODELS.BINARIESmodel:
                 if self.double_lined:
                     n_KOparameters = 8 * self.nKO
@@ -1484,6 +1487,9 @@ class KimaResults:
             KO_priors += [self.priors[f'KO_phiprior_{i}'] for i in range(self.nKO)]
             KO_priors += [self.priors[f'KO_eprior_{i}'] for i in range(self.nKO)]
             KO_priors += [self.priors[f'KO_wprior_{i}'] for i in range(self.nKO)]
+            if self.model is MODELS.RVHGPMmodel:
+                KO_priors += [self.priors[f'KO_iprior_{i}'] for i in range(self.nKO)]
+                KO_priors += [self.priors[f'KO_Wprior_{i}'] for i in range(self.nKO)]
             priors[self.indices['KOpars']] = KO_priors
 
         if self.TR:
@@ -2206,6 +2212,13 @@ class KimaResults:
                 self.posteriors.KO.a = self.KOpars[:, range(3*self.nKO, 4*self.nKO)]
                 self.posteriors.KO.w = self.KOpars[:, range(4*self.nKO, 5*self.nKO)]
                 self.posteriors.KO.cosi = self.KOpars[:, range(5*self.nKO, 6*self.nKO)]
+                self.posteriors.KO.W = self.KOpars[:, range(6*self.nKO, 7*self.nKO)]
+            elif self.model is MODELS.RVHGPMmodel:
+                self.posteriors.KO.K = self.KOpars[:, range(1*self.nKO, 2*self.nKO)]
+                self.posteriors.KO.φ = self.KOpars[:, range(2*self.nKO, 3*self.nKO)]
+                self.posteriors.KO.e = self.KOpars[:, range(3*self.nKO, 4*self.nKO)]
+                self.posteriors.KO.w = self.KOpars[:, range(4*self.nKO, 5*self.nKO)]
+                self.posteriors.KO.i = self.KOpars[:, range(5*self.nKO, 6*self.nKO)]
                 self.posteriors.KO.W = self.KOpars[:, range(6*self.nKO, 7*self.nKO)]
             else:
                 self.posteriors.KO.K = self.KOpars[:, range(1*self.nKO, 2*self.nKO)]


### PR DESCRIPTION
This PR fixes the RVHGPMmodel so that a "known object" is properly included in a fit.  

Before, only the RV parameters of a known object were included in the C++ header and implementation files for the RVHGPMmodel.  This PR therefore adds the inclination and longitude of ascending node to the known object in the RVHGPMmodel, and also switches the calculation of mu to reflect this change (i.e., it now calculates the orbit of a known object using `brandt::keplerian_rvpm`, instead of `brandt::keplerian`).

Known objects are also now included by default (if they are included in a fit), in the period posteriors and "joint posteriors" plots in the report pdf.  

More importantly, known objects are now also included and labelled in HGPM plots.  After some testing, I can also confirm that the [latest commit to kima as of making this PR](https://github.com/kima-org/kima/commit/667db95db79c2706e8d76b0659c489c28037416a) does indeed fix the issue with a known object's orbit being offset from the data in this plot, as well as the barycentric proper motion having an unexpected offset (see example screenshots below, where the only difference between the fits, from left to right, is using the latest commit to `kima`).

<img width="929" height="187" alt="image" src="https://github.com/user-attachments/assets/af9f5af3-bde8-4f14-bc18-2e03c2878724" />

<img width="929" height="189" alt="image" src="https://github.com/user-attachments/assets/d06db3d5-633a-4b24-9c08-19f4dd762e04" />

Finally, the parameters for a known object listed in a `KimaResults` instance now include inclination and longitude of ascending node, both for its priors and posteriors.

Some caveats with this PR:

1. I did not add the 2 additional orbital parameters for a known object fit with RVHGPMmodel in the `orbit` or `simulation` functions of display.py - I do not think these functions are relevant for anything I am doing or plotting.
2. As stated previously, the `parameter_priors` property of the `KimaResults` class will now work properly for a known object used in the RVHGPMmodel, but it is almost certainly broken when getting the priors for a known object fit in the RVGAIAmodel or GAIAmodel - although this was already a problem before this PR, so I did not fix this.
3. The `print_results` function of the `KimaResults` class will not print the inclination or longitude of ascending node of a known object in the case of a RVHGPMmodel fit - pettily enough, I did not fix this since I do not think it affects any of the actual results or any plotting, and I do not use this function explicitly in any of my scripts. 

